### PR TITLE
Switch base image to ubuntu:16.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
       - run:
           name: Build Docker image
-          command: docker build -t monacoind .
+          command: docker build --cache-from monacoind -t monacoind .
 
       - run:
           name: Save Docker image layer cache
@@ -40,4 +40,4 @@ jobs:
       - save_cache:
           key: v1-{{ .Branch }}-{{ epoch }}
           paths:
-            - /caches/app.tar
+            - /caches/monacoind.tar

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,9 @@ RUN ./configure --disable-tests --disable-bench
 RUN make -j "$(nproc)"
 RUN make install
 
+VOLUME ["/root/.monacoin"]
+
+# P2P = 9401, RPC = 9402
+EXPOSE 9401 9402
+
 CMD ["monacoind"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,26 @@
-FROM alpine:3.6
+FROM ubuntu:16.04
 
-RUN apk update
-RUN apk add \
-  autoconf \
-  automake \
-  boost-dev \
-  coreutils \
-  curl \
-  file \
-  gcc \
-  g++ \
-  libevent-dev \
-  libtool \
-  make \
-  openssl-dev
+# RUN locale-gen en_US.UTF-8
+# ENV LANG en_US.utf8
+# ENV LC_ALL en_US.UTF-8
+
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    curl \
+    gcc \
+    g++ \
+    libboost-dev \
+    libboost-filesystem-dev \
+    libboost-program-options-dev \
+    libboost-system-dev \
+    libboost-thread-dev \
+    libevent-dev \
+    libssl-dev \
+    libtool \
+    make \
+    pkg-config
+
+RUN apt-get clean
 
 # Build db4.8
 WORKDIR /tmp


### PR DESCRIPTION
monacoind and musl libc wasn't the best duo; configure hangs on a wait(1), and monacoind ends up in a SEGV on startup. Therefore, we're just moving to Ubuntu (we've tried Debian, but make didn't work out (hadn't investigated throughly)).